### PR TITLE
Revert "Fixes Issue #21 - Automates Event File Index"

### DIFF
--- a/A32nx/LINDA/aircrafts/FBW A320/actions.lua
+++ b/A32nx/LINDA/aircrafts/FBW A320/actions.lua
@@ -2496,21 +2496,6 @@ function InitVars ()
     A32NX_ALT_Zero = '0'
     A32NX_Dot = string.char(7)
     A32NX_NoDot = ' '
-	
-    -- define index to custom events in A32NX.EVT
-	EvtFile = "A32NX"
-    EvtCnt = ipc.get("EVTNUM")
-    for i = 0, EvtCnt - 1 do
-        f = ipc.get("EVTFILE" .. tostring(i))
-        if f == EvtFile then
-            EvtIdx = i
-            break
-        end
-    end
-    _loggg('[USER] EvtIdx=' .. tostring(EvtIdx) .. '::' .. f)
-
-    -- defined in [EVENTS] block in FSUIPC7.INI
-    EvtPtr = 32768 + (EvtIdx * 256) -- start address for A32NX.EVT custom events
 end
 
 function Timer ()


### PR DESCRIPTION
Reverts joeherwig/A32nx-LINDA-aircraft-module#31

Sry. Didn't work for me...
Maybe we need to make a brief call about. Didn't get it running.
And on finding the file name we should ensure to have it case insensitive as Windows doesn't allow easy renaming of an lower case to upercase filename while lua expects it case sensitive...